### PR TITLE
Train bbox variance with beta nll

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -289,7 +289,7 @@ def visual_grounding(image, text):
 
             cls_output = net_output[0]
             cls_type = torch.argmax(cls_output, 2)
-            reg_output = net_output[1].squeeze(-1)
+            reg_output = net_output[1].mean
             attn = net_output[2]['attn']
             attn_arrays = [att.detach().cpu().numpy() for att in attn]
             attn_arrays = np.concatenate(attn_arrays, 0)

--- a/tasks/refcoco.py
+++ b/tasks/refcoco.py
@@ -228,7 +228,7 @@ class RefcocoTask(BaseTask):
 
                 cls_output = net_output[0]
                 cls_type = torch.argmax(cls_output, 2)
-                reg_output = net_output[1]
+                reg_output = net_output[1].mean
                 for j in range(b):
                     if unfinish_flag[j] == 1:  # prediction is not finished
                         cls_j = cls_type[j, i].item()

--- a/tasks/refcoco_pretrain.py
+++ b/tasks/refcoco_pretrain.py
@@ -214,9 +214,9 @@ class RefcocoPretrainTask(BaseTask):
                     src_lengths=sample['net_input']['src_lengths'],
                     return_all_hiddens=False
                 )
-                net_output = net_output[1]
+                reg_output = net_output[1].mean
                 for j in range(b):
-                    output_j_x, output_j_y = net_output[j, i].cpu().numpy()
+                    output_j_x, output_j_y = reg_output[j, i].cpu().numpy()
                     gen_out[j].extend([output_j_x, output_j_y])
 
                     output_j_x = output_j_x * (n_bins - 1)


### PR DESCRIPTION
## Summary
- Replace L1 coordinate loss with Beta distribution negative log-likelihood so the decoder learns both mean and variance

## Testing
- `python -m py_compile models/polyformer/unify_transformer.py demo.py tasks/refcoco.py tasks/refcoco_pretrain.py criterions/label_smoothed_cross_entropy.py`
- `pytest -q` *(fails: ValueError: mutable default <class 'hydra.conf.JobConf.JobConfig.OverrideDirname'> for field override_dirname is not allowed: use default_factory)*

------
https://chatgpt.com/codex/tasks/task_e_68b75366f06883278c9c6e28e9a2b588